### PR TITLE
Use default location before env var

### DIFF
--- a/s3file/storages.py
+++ b/s3file/storages.py
@@ -57,4 +57,4 @@ storage = default_storage if not local_dev else S3MockStorage()
 
 
 def get_aws_location():
-    return getattr(settings, "AWS_LOCATION", "")
+    return storage.location or getattr(settings, "AWS_LOCATION", "")


### PR DESCRIPTION
Location can be set in the storages handler class used by django-storages, this will override the variable set in the .env